### PR TITLE
Adding border support

### DIFF
--- a/UIImage+Additions.h
+++ b/UIImage+Additions.h
@@ -76,15 +76,17 @@ typedef enum __UIImageGradientDirection
  */
 + (UIImage*)imageWithColor:(UIColor*)color;
 + (UIImage*)imageWithColor:(UIColor*)color size:(CGSize)size;
-+ (UIImage*)imageWithColor:(UIColor*)color size:(CGSize)size cornerRadius:(CGFloat)cornerRadius;
-+ (UIImage*)imageWithColor:(UIColor*)color size:(CGSize)size cornerInset:(UICornerInset)cornerInset;
++ (UIImage*)imageWithColor:(UIColor*)color borderAttributes:(NSDictionary*)borderAttributes size:(CGSize)size;
++ (UIImage*)imageWithColor:(UIColor*)color borderAttributes:(NSDictionary*)borderAttributes size:(CGSize)size cornerRadius:(CGFloat)cornerRadius;
++ (UIImage*)imageWithColor:(UIColor*)color borderAttributes:(NSDictionary*)borderAttributes size:(CGSize)size cornerInset:(UICornerInset)cornerInset;
 
 /*
  * Create rezisable images from colors
  */
 + (UIImage*)resizableImageWithColor:(UIColor*)color;
 + (UIImage*)resizableImageWithColor:(UIColor*)color cornerRadius:(CGFloat)cornerRadius;
-+ (UIImage*)resizableImageWithColor:(UIColor*)color cornerInset:(UICornerInset)cornerInset;
++ (UIImage*)resizableImageWithColor:(UIColor*)color borderAttributes:(NSDictionary*)borderAttributes cornerRadius:(CGFloat)cornerRadius;
++ (UIImage*)resizableImageWithColor:(UIColor*)color borderAttributes:(NSDictionary*)borderAttributes cornerInset:(UICornerInset)cornerInset;
 
 + (UIImage*)blackColorImage;
 + (UIImage*)darkGrayColorImage;

--- a/UIImage+Additions.m
+++ b/UIImage+Additions.m
@@ -64,6 +64,7 @@ static NSCache * _imageCache = nil;
 static NSString * kUIImageName = @"kUIImageName";
 static NSString * kUIImageResizableImage = @"kUIImageResizableImage";
 static NSString * kUIImageColors = @"kUIImageColors";
+static NSString * kUIImageBorderAttributes = @"kUIImageBorderAttributes";
 static NSString * kUIImageTintColor = @"kUIImageTintColor";
 static NSString * kUIImageTintStyle = @"kUIImageTintStyle";
 static NSString * kUIImageCornerInset = @"kUIImageCornerInset";
@@ -79,36 +80,47 @@ static NSString * kUIImageSize = @"kUIImageSize";
 
 + (UIImage*)imageWithColor:(UIColor*)color size:(CGSize)size
 {
-    return [self imageWithColor:color size:size cornerInset:UICornerInsetZero];
+    return [self imageWithColor:color borderAttributes:nil size:size cornerInset:UICornerInsetZero];
 }
 
-+ (UIImage*)imageWithColor:(UIColor*)color size:(CGSize)size cornerRadius:(CGFloat)cornerRadius
++ (UIImage*)imageWithColor:(UIColor*)color borderAttributes:(NSDictionary*)borderAttributes size:(CGSize)size
 {
-    return [self imageWithColor:color size:size cornerInset:UICornerInsetMake(cornerRadius, cornerRadius, cornerRadius, cornerRadius)];
+    return [self imageWithColor:color borderAttributes:borderAttributes size:size cornerInset:UICornerInsetZero];
 }
 
-+ (UIImage*)imageWithColor:(UIColor*)color size:(CGSize)size cornerInset:(UICornerInset)cornerInset
++ (UIImage*)imageWithColor:(UIColor*)color borderAttributes:(NSDictionary*)borderAttributes size:(CGSize)size cornerRadius:(CGFloat)cornerRadius
 {
-    return [self _imageWithColor:color size:size cornerInset:cornerInset saveInCache:YES];
+    return [self imageWithColor:color borderAttributes:borderAttributes size:size cornerInset:UICornerInsetMake(cornerRadius, cornerRadius, cornerRadius, cornerRadius)];
+}
+
++ (UIImage*)imageWithColor:(UIColor*)color borderAttributes:(NSDictionary*)borderAttributes size:(CGSize)size cornerInset:(UICornerInset)cornerInset
+{
+    return [self _imageWithColor:color borderAttributes:borderAttributes size:size cornerInset:cornerInset saveInCache:YES];
 }
 
 + (UIImage*)resizableImageWithColor:(UIColor*)color
 {
-    return [self resizableImageWithColor:color cornerInset:UICornerInsetZero];
+    return [self resizableImageWithColor:color borderAttributes:nil cornerInset:UICornerInsetZero];
 }
 
-+ (UIImage*)resizableImageWithColor:(UIColor*)color cornerRadius:(CGFloat)cornerRadius
++ (UIImage*)resizableImageWithColor:(UIColor*)color cornerRadius:(CGFloat)cornerRadius;
 {
-    return [self resizableImageWithColor:color cornerInset:UICornerInsetMake(cornerRadius, cornerRadius, cornerRadius, cornerRadius)];
+    return [self resizableImageWithColor:color borderAttributes:nil cornerInset:UICornerInsetMake(cornerRadius, cornerRadius, cornerRadius, cornerRadius)];
 }
 
-+ (UIImage*)resizableImageWithColor:(UIColor*)color cornerInset:(UICornerInset)cornerInset
++ (UIImage*)resizableImageWithColor:(UIColor*)color borderAttributes:(NSDictionary*)borderAttributes cornerRadius:(CGFloat)cornerRadius
+{
+    return [self resizableImageWithColor:color borderAttributes:borderAttributes cornerInset:UICornerInsetMake(cornerRadius, cornerRadius, cornerRadius, cornerRadius)];
+}
+
++ (UIImage*)resizableImageWithColor:(UIColor*)color borderAttributes:(NSDictionary*)borderAttributes cornerInset:(UICornerInset)cornerInset
 {
     if (!color)
         return nil;
     
     NSDictionary *descriptors =  @{kUIImageColors : @[color],
                                    kUIImageResizableImage : @YES,
+                                   kUIImageBorderAttributes : borderAttributes ?: [NSNull null],
                                    kUIImageCornerInset : [NSValue valueWithUICornerInset:cornerInset]};
     
     UIImage *image = [self _cachedImageWithDescriptors:descriptors];
@@ -116,15 +128,17 @@ static NSString * kUIImageSize = @"kUIImageSize";
     if (image)
         return image;
     
-    CGSize size = CGSizeMake(MAX(cornerInset.topLeft, cornerInset.bottomLeft) + MAX(cornerInset.topRight, cornerInset.bottomRight) + 1,
-                             MAX(cornerInset.topLeft, cornerInset.topRight) + MAX(cornerInset.bottomLeft, cornerInset.bottomRight) + 1);
+    CGFloat borderWidth = [borderAttributes[NSStrokeWidthAttributeName] floatValue];
+
+    CGSize size = CGSizeMake(MAX(cornerInset.topLeft, cornerInset.bottomLeft) + MAX(cornerInset.topRight, cornerInset.bottomRight) + borderWidth * 2 + 1,
+                             MAX(cornerInset.topLeft, cornerInset.topRight) + MAX(cornerInset.bottomLeft, cornerInset.bottomRight) + borderWidth * 2 + 1);
     
-    UIEdgeInsets capInsets = UIEdgeInsetsMake(MAX(cornerInset.topLeft, cornerInset.topRight),
-                                              MAX(cornerInset.topLeft, cornerInset.bottomLeft),
-                                              MAX(cornerInset.bottomLeft, cornerInset.bottomRight),
-                                              MAX(cornerInset.topRight, cornerInset.bottomRight));
+    UIEdgeInsets capInsets = UIEdgeInsetsMake(MAX(cornerInset.topLeft, cornerInset.topRight) + borderWidth,
+                                              MAX(cornerInset.topLeft, cornerInset.bottomLeft) + borderWidth,
+                                              MAX(cornerInset.bottomLeft, cornerInset.bottomRight) + borderWidth,
+                                              MAX(cornerInset.topRight, cornerInset.bottomRight) + borderWidth);
     
-    image = [[self imageWithColor:color size:size cornerInset:cornerInset] resizableImageWithCapInsets:capInsets];
+    image = [[self imageWithColor:color borderAttributes:borderAttributes size:size cornerInset:cornerInset] resizableImageWithCapInsets:capInsets];
     
     [self _cacheImage:image withDescriptors:descriptors];
     
@@ -427,18 +441,33 @@ static NSString * kUIImageSize = @"kUIImageSize";
     for (UIColor *color in colors)
         [string appendFormat:@"%ld",(long)color.hash];
     [string appendFormat:@">"];
+
+    NSDictionary *borderAttributes = descriptors[kUIImageBorderAttributes];
+    if (![borderAttributes isEqual:[NSNull null]]) {
+        UIColor *borderColor = borderAttributes[NSStrokeColorAttributeName];
+        NSNumber *borderWidth = borderAttributes[NSStrokeWidthAttributeName];
+        [string appendFormat:@"<%@:%ld%f>", kUIImageBorderAttributes, borderColor.hash, borderWidth.floatValue];
+    }
     
     [string appendFormat:@"<%@:%ld>",kUIImageTintColor,(long)[[descriptors valueForKey:kUIImageTintColor] hash]];
     [string appendFormat:@"<%@:%ld>",kUIImageTintStyle,(long)[[descriptors valueForKey:kUIImageTintStyle] integerValue]];
     [string appendFormat:@"<%@:%@>",kUIImageCornerInset,NSStringFromUICornerInset([[descriptors valueForKey:kUIImageCornerInset] UICornerInsetValue])];
     [string appendFormat:@"<%@:%ld>",kUIImageGradientDirection,(long)[[descriptors valueForKey:kUIImageGradientDirection] integerValue]];
     
+    NSLog(@"key: %@", string);
+    
     return [string md5];
 }
 
 + (UIImage*)_imageWithColor:(UIColor*)color size:(CGSize)size cornerInset:(UICornerInset)cornerInset saveInCache:(BOOL)save
 {
+    return [self _imageWithColor:color borderAttributes:nil size:size cornerInset:cornerInset saveInCache:save];
+}
+
++ (UIImage*)_imageWithColor:(UIColor*)color borderAttributes:(NSDictionary *)borderAttributes size:(CGSize)size cornerInset:(UICornerInset)cornerInset saveInCache:(BOOL)save
+{
     NSDictionary *descriptors =  @{kUIImageColors : @[color],
+                                   kUIImageBorderAttributes : borderAttributes ?: [NSNull null],
                                    kUIImageSize : [NSValue valueWithCGSize:size],
                                    kUIImageCornerInset : [NSValue valueWithUICornerInset:cornerInset]};
 
@@ -463,6 +492,10 @@ static NSString * kUIImageSize = @"kUIImageSize";
     if (context == NULL)
         return nil;
     
+    UIColor *borderColor = borderAttributes[NSStrokeColorAttributeName];
+    NSNumber *borderWidth = borderAttributes[NSStrokeWidthAttributeName];
+    rect = CGRectInset(rect, [borderWidth floatValue] / 2.0, [borderWidth floatValue] / 2.0);
+    
     CGFloat minx = CGRectGetMinX(rect), midx = CGRectGetMidX(rect), maxx = CGRectGetMaxX(rect);
     CGFloat miny = CGRectGetMinY(rect), midy = CGRectGetMidY(rect), maxy = CGRectGetMaxY(rect);
     
@@ -472,6 +505,11 @@ static NSString * kUIImageSize = @"kUIImageSize";
     CGContextClosePath(context);
     CGContextDrawPath(context, kCGPathFill);
     
+    if (borderColor)
+        CGContextSetStrokeColorWithColor(context, [borderColor CGColor]);
+    if (borderWidth)
+        CGContextSetLineWidth(context, [borderWidth floatValue]);
+    
     CGContextSetFillColorWithColor(context, [color CGColor]); // <-- Color to fill
     CGContextBeginPath(context);
     CGContextMoveToPoint(context, minx, midy);
@@ -480,7 +518,7 @@ static NSString * kUIImageSize = @"kUIImageSize";
     CGContextAddArcToPoint(context, maxx, maxy, midx, maxy, cornerInset.topRight);
     CGContextAddArcToPoint(context, minx, maxy, minx, midy, cornerInset.topLeft);
     CGContextClosePath(context);
-    CGContextDrawPath(context, kCGPathFill);
+    CGContextDrawPath(context, borderColor || borderWidth ? kCGPathFillStroke : kCGPathFill);
     
     CGImageRef bitmapContext = CGBitmapContextCreateImage(context);
     


### PR DESCRIPTION
#### Summary
- Added `borderAttributes` parameter for all methods.
- `borderAttributes` is a `NSDictionary` that contains `NSStrokeColorAttributeName` and `NSStrokeWidthAttributeName`.
- Cache supported.
#### Usage
##### 1. Fixed size bordered-image

``` objc
NSDictionary *borderAttributes1 = @{NSStrokeColorAttributeName: [UIColor blueColor],
                                    NSStrokeWidthAttributeName: @(3)};

UIImage *image = [UIImage imageWithColor:[UIColor redColor] borderAttributes:borderAttributes1
                                    size:CGSizeMake(100, 100)
                            cornerRadius:10];
UIImageView *imageView = [[UIImageView alloc] initWithImage:image];
imageView.center = CGPointMake(160, 200);
[self.window addSubview:imageView];
```
##### 2. Resizable bordered-image

``` objc
NSDictionary *borderAttributes2 = @{NSStrokeColorAttributeName: [UIColor darkGrayColor],
                                    NSStrokeWidthAttributeName: @(20)};

UIImage *resizableImage = [UIImage resizableImageWithColor:[UIColor lightGrayColor]
                                          borderAttributes:borderAttributes2
                                              cornerRadius:10];
UIImageView *resizableImageView = [[UIImageView alloc] initWithImage:resizableImage];
resizableImageView.frame = CGRectMake(10, 300, 300, 100);
[self.window addSubview:resizableImageView];
```
