### PR TITLE
add_imageWithColor shouldn't crash if color is nil

### DIFF
--- a/UIImage+Additions.m
+++ b/UIImage+Additions.m
@@ -444,6 +444,9 @@ static NSString * kUIImageSize = @"kUIImageSize";
 
 + (UIImage*)add_imageWithColor:(UIColor*)color size:(CGSize)size cornerInset:(ADDCornerInset)cornerInset saveInCache:(BOOL)save
 {
+    if (!color)
+        return nil;
+
     NSDictionary *descriptors =  @{kUIImageColors : @[color],
                                    kUIImageSize : [NSValue valueWithCGSize:size],
                                    kUIImageCornerInset : [NSValue valueWithADDCornerInset:cornerInset]};


### PR DESCRIPTION
This nil check exists in a few different methods, not sure why it doesn't here.  If `color` is nil, then `@[color]` will crash